### PR TITLE
Added "Visible" property

### DIFF
--- a/UI/Components/ButtonComponent.cs
+++ b/UI/Components/ButtonComponent.cs
@@ -13,6 +13,7 @@ public class ButtonComponent : MenuComponent
     public string Text { internal get; set; } = "Button";
     public bool ShowCaret { internal get; set; } = true;
     public bool Enabled { get; set; } = true;
+    public bool Visible { get; set; } = true;
     public Action<ButtonComponent> OnClick { internal get; set; } = (self) => { };
 
     /// <summary>
@@ -49,6 +50,7 @@ internal class ButtonComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         button.interactable = component.Enabled;
         label.text = $"{(component.ShowCaret ? "> " : "")}{component.Text}";
     }

--- a/UI/Components/DropdownComponent.cs
+++ b/UI/Components/DropdownComponent.cs
@@ -10,6 +10,7 @@ public class DropdownComponent : MenuComponent
 {
     public string Text { get; set; }
     public bool Enabled { get; set; } = true;
+    public bool Visible { get; set; } = true;
     public List<TMP_Dropdown.OptionData> Options { get; set; } = [];
     public Action<DropdownComponent, TMP_Dropdown.OptionData> OnValueChanged { get; set; } = (self, value) => { };
 
@@ -97,6 +98,7 @@ internal class DropdownComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         dropdown.interactable = component.Enabled;
         title.text = component.Text;
         if (component.Options != dropdown.options)

--- a/UI/Components/InputComponent.cs
+++ b/UI/Components/InputComponent.cs
@@ -9,6 +9,7 @@ namespace LethalSettings.UI.Components;
 public class InputComponent : MenuComponent
 {
     public string Placeholder { get; set; } = "Enter text...";
+    public bool Visible { get; set; } = true;
     public Action<InputComponent, string> OnValueChanged { get; set; } = (self, value) => { };
     
     /// <summary>
@@ -77,6 +78,7 @@ internal class InputComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         placeholder.text = component.Placeholder;
         input.text = component.Value;
     }

--- a/UI/Components/LabelComponent.cs
+++ b/UI/Components/LabelComponent.cs
@@ -10,6 +10,7 @@ public class LabelComponent : MenuComponent
 {
     public string Text { internal get; set; } = "Label Text";
     public float FontSize { internal get; set; } = 16;
+    public bool Visible { get; set; } = true;
     public TextAlignmentOptions Alignment { internal get; set; } = TextAlignmentOptions.MidlineLeft;
 
     /// <summary>
@@ -41,6 +42,7 @@ internal class LabelComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         label.text = component.Text;
         label.fontSize = component.FontSize;
         label.alignment = component.Alignment;

--- a/UI/Components/SliderComponent.cs
+++ b/UI/Components/SliderComponent.cs
@@ -13,6 +13,7 @@ public class SliderComponent : MenuComponent
     public bool ShowValue { get; set; } = true;
     public bool WholeNumbers {  get; set; } = true;
     public bool Enabled { get; set;} = true;
+    public bool Visible { get; set; } = true;
     public float MinValue { get; set; } = 0f;
     public float MaxValue { get; set; } = 100f;
 
@@ -78,6 +79,7 @@ internal class SliderComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         slider.wholeNumbers = component.WholeNumbers;
         slider.interactable = component.Enabled;
         slider.minValue = component.MinValue;

--- a/UI/Components/ToggleComponent.cs
+++ b/UI/Components/ToggleComponent.cs
@@ -12,6 +12,7 @@ public class ToggleComponent : MenuComponent
     public string Text { get; set; } = "Toggle";
     public int FontSize { get; set; } = 15;
     public bool Enabled { get; set; } = true;
+    public bool Visible { get; set; } = true;
 
     internal bool _toggled;
     public bool Value
@@ -72,6 +73,7 @@ internal class ToggleComponentObject : MonoBehaviour
 
     private void FixedUpdate()
     {
+        gameObject.SetActive(component.Visible);
         button.interactable = component.Enabled;
         label.text = component.Text;
         label.fontSize = component.FontSize;


### PR DESCRIPTION
Added `Visible` properties to all non-layout components. The implementation is a bit repetitive since the layout components don't have MonoBehaviours to update their state.

I want this specifically for making a search feature, but I imagine it's useful for a lot of other use cases.
![image](https://github.com/willis81808/LethalSettings/assets/113015915/92cc4ac5-59da-4aa9-83c9-fc1fc0b45cc4)
